### PR TITLE
fix: allow patch and delete in CORS preflight

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -45,7 +45,11 @@ export async function buildApp(): Promise<FastifyInstance> {
   });
 
   if (config.corsOrigins.length > 0) {
-    await app.register(cors, { origin: config.corsOrigins, credentials: true });
+    await app.register(cors, {
+      origin: config.corsOrigins,
+      credentials: true,
+      methods: ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
+    });
   }
 
   // Dev static serving: mount jp-site at / so cookies are single-origin.


### PR DESCRIPTION
Volunteer and registration removal from the production poolparty site fail in-browser because preflight only advertises GET, HEAD, and POST. Explicitly allow PATCH, DELETE, and OPTIONS for the configured cross-origin frontend.